### PR TITLE
Bugfix: Serializer settings passthrough

### DIFF
--- a/Runtime/SimpleGraphQL/HttpUtils.cs
+++ b/Runtime/SimpleGraphQL/HttpUtils.cs
@@ -93,7 +93,7 @@ namespace SimpleGraphQL
             
             var uri = new Uri(url);
 
-            string payload = request.ToJson();
+            string payload = request.ToJson(false, serializerSettings);
             
             var requestMessage = new HttpRequestMessage();
             //byte[] payload = request.ToBytes(serializerSettings);


### PR DESCRIPTION
Mobile uses custom serializers for Color / Vector types. This fixes a self-referencing loop error during serialization.