### PR TITLE
Implemented fragments shared between multiple queries

### DIFF
--- a/Editor/SimpleGraphQL/GraphQLFragmentImporter.cs
+++ b/Editor/SimpleGraphQL/GraphQLFragmentImporter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEngine;
+using SimpleGraphQL.GraphQLParser;
+using SimpleGraphQL.GraphQLParser.AST;
+
+// ifdef for different unity versions
+#if UNITY_2020_2_OR_NEWER
+using UnityEditor.AssetImporters;
+
+#elif UNITY_2017_1_OR_NEWER
+using UnityEditor.Experimental.AssetImporters;
+#endif
+
+namespace SimpleGraphQL
+{
+    [ScriptedImporter(1, "graphqlfrag")]
+    public class GraphQLFragmentImporter : ScriptedImporter
+    {
+        public override void OnImportAsset(AssetImportContext ctx)
+        {
+            var lexer = new Lexer();
+            var parser = new Parser(lexer);
+            string contents = File.ReadAllText(ctx.assetPath);
+            var queryFile = ScriptableObject.CreateInstance<GraphQLFragmentFile>();
+
+            GraphQLDocument graphQLDocument = parser.Parse(new Source(contents));
+
+            List<GraphQLFragmentDefinition> operations = graphQLDocument.Definitions
+                .FindAll(x => x.Kind == ASTNodeKind.FragmentDefinition)
+                .Select(x => (GraphQLFragmentDefinition) x)
+                .ToList();
+
+            if (operations.Count > 0)
+            {
+                foreach (GraphQLFragmentDefinition operation in operations)
+                {
+                    queryFile.Fragment = new Fragment
+                                         {
+                                             Name = operation.Name?.Value,
+                                             TypeCondition = operation.TypeCondition?.Name?.Value,
+                                             Source = contents
+                                         };
+                }
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"There were no operation definitions inside this graphql: {ctx.assetPath}\nPlease ensure that there is at least one operation defined!");
+            }
+
+            ctx.AddObjectToAsset("FragmentScriptableObject", queryFile);
+            ctx.SetMainObject(queryFile);
+        }
+    }
+}

--- a/Editor/SimpleGraphQL/GraphQLFragmentImporter.cs.meta
+++ b/Editor/SimpleGraphQL/GraphQLFragmentImporter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: afea354c10f04202a2f39b4c0c58dd3a
+timeCreated: 1700827700

--- a/Editor/SimpleGraphQL/GraphQLImporterV1.cs
+++ b/Editor/SimpleGraphQL/GraphQLImporterV1.cs
@@ -51,12 +51,15 @@ namespace SimpleGraphQL
                         Debug.LogWarning("Unable to convert operation type in " + ctx.assetPath);
                     }
 
+                    var fragments = operation.Descendants().Where(node => node is GraphQLFragmentSpread).Select(node => ((GraphQLFragmentSpread)node).Name.Value).ToArray();
+                    
                     queryFile.Queries.Add(new Query
                     {
                         FileName = fileName,
                         OperationName = operation.Name?.Value,
                         OperationType = operationType,
-                        Source = contents
+                        Source = contents,
+                        Fragments = fragments
                     });
                 }
             }

--- a/Plugins/SimpleGraphQL/GraphQLParser/AST/ASTNode.cs
+++ b/Plugins/SimpleGraphQL/GraphQLParser/AST/ASTNode.cs
@@ -1,4 +1,7 @@
-﻿namespace SimpleGraphQL.GraphQLParser.AST
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace SimpleGraphQL.GraphQLParser.AST
 {
     public abstract class ASTNode
     {
@@ -7,5 +10,38 @@
         public GraphQLLocation Location { get; set; }
 
         public GraphQLComment Comment { get; set; }
+        
+    }
+    
+    public static class ASTNodeExtensions
+    {
+        public static IEnumerable<ASTNode> Descendants(this ASTNode root)
+        {
+            var nodes = new Stack<ASTNode>(new[] {root});
+            while (nodes.Any())
+            {
+                ASTNode node = nodes.Pop();
+                yield return node;
+
+                GraphQLSelectionSet selectionSet = null;
+                
+                if (node is GraphQLFieldSelection fieldSelection)
+                {
+                    selectionSet = fieldSelection.SelectionSet;
+                }
+
+                if (node is GraphQLOperationDefinition operationDefinition)
+                {
+                    selectionSet = operationDefinition.SelectionSet;
+                }
+                
+                if(selectionSet != null && selectionSet.Selections != null)
+                { 
+                    foreach (var n in selectionSet.Selections) 
+                        nodes.Push(n);
+                }
+            }
+        }
+
     }
 }

--- a/Runtime/SimpleGraphQL/Fragment.cs
+++ b/Runtime/SimpleGraphQL/Fragment.cs
@@ -1,0 +1,52 @@
+using System;
+using JetBrains.Annotations;
+using UnityEngine;
+
+namespace SimpleGraphQL
+{
+    [PublicAPI]
+    [Serializable]
+    public class Fragment
+    {
+        /// <summary>
+        /// The name of the fragment.
+        /// </summary>
+        [CanBeNull]
+        public string Name;
+
+        /// <summary>
+        /// The type the fragment is selecting from.
+        /// </summary>
+        public string TypeCondition;
+
+        /// <summary>
+        /// The actual fragment itself.
+        /// </summary>
+        [TextArea]
+        public string Source;
+
+        public override string ToString()
+        {
+            return $"fragment {Name} on {TypeCondition}";
+        }
+        
+        protected bool Equals(Fragment other)
+        {
+            return Name == other.Name;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Fragment)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Name != null ? Name.GetHashCode() : 0);
+        }
+    }
+
+}

--- a/Runtime/SimpleGraphQL/Fragment.cs.meta
+++ b/Runtime/SimpleGraphQL/Fragment.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e7c80271ce3481ea2730ffdd022ecdd
+timeCreated: 1700841659

--- a/Runtime/SimpleGraphQL/GraphQLClient.cs
+++ b/Runtime/SimpleGraphQL/GraphQLClient.cs
@@ -16,6 +16,7 @@ namespace SimpleGraphQL
     {
         public readonly List<Query> SearchableQueries;
         public readonly Dictionary<string, string> CustomHeaders;
+        public readonly Dictionary<string, Fragment> Fragments;
 
         public string Endpoint;
         public string AuthScheme;
@@ -24,13 +25,14 @@ namespace SimpleGraphQL
             string endpoint,
             IEnumerable<Query> queries = null,
             Dictionary<string, string> headers = null,
-            string authScheme = null
-        )
+            string authScheme = null,
+            IEnumerable<Fragment> fragments = null)
         {
             Endpoint = endpoint;
             AuthScheme = authScheme;
             SearchableQueries = queries?.ToList();
             CustomHeaders = headers;
+            Fragments = fragments?.ToDictionary(fragment => fragment.Name);
         }
 
         public GraphQLClient(GraphQLConfig config)
@@ -39,6 +41,7 @@ namespace SimpleGraphQL
             SearchableQueries = config.Files.SelectMany(x => x.Queries).ToList();
             CustomHeaders = config.CustomHeaders.ToDictionary(header => header.Key, header => header.Value);
             AuthScheme = config.AuthScheme;
+            Fragments = config.Fragments.ToDictionary(file => file.Fragment.Name, file => file.Fragment);
         }
 
         /// <summary>
@@ -341,6 +344,26 @@ namespace SimpleGraphQL
         public List<Query> FindQueriesByOperation(string operation)
         {
             return SearchableQueries?.FindAll(x => x.OperationName == operation);
+        }
+
+        public List<Fragment> FindFragments(IEnumerable<string> fragmentNames)
+        {
+            List<Fragment> fragments = new();
+
+            if (fragmentNames == null)
+            {
+                return fragments;
+            }
+            
+            foreach (var fragmentName in fragmentNames)
+            {
+                if (Fragments.TryGetValue(fragmentName, out var fragment))
+                {
+                    fragments.Add(fragment);
+                }
+            }
+
+            return fragments;
         }
     }
 }

--- a/Runtime/SimpleGraphQL/GraphQLConfig.cs
+++ b/Runtime/SimpleGraphQL/GraphQLConfig.cs
@@ -20,6 +20,9 @@ namespace SimpleGraphQL
         [Header(".graphql Files")]
         public List<GraphQLFile> Files;
 
+        [Header("Fragment files")]
+        public List<GraphQLFragmentFile> Fragments;
+        
         /// <summary>
         /// Set the auth scheme to be used here if you need authentication.
         /// You can also use CustomHeaders to pass in authentication if needed, but this is inherently less secure.

--- a/Runtime/SimpleGraphQL/GraphQLFragmentFile.cs
+++ b/Runtime/SimpleGraphQL/GraphQLFragmentFile.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SimpleGraphQL
+{
+    public class GraphQLFragmentFile : ScriptableObject
+    {
+        public Fragment Fragment;
+    }
+}

--- a/Runtime/SimpleGraphQL/GraphQLFragmentFile.cs.meta
+++ b/Runtime/SimpleGraphQL/GraphQLFragmentFile.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ed536702a30f4d66a351082674fda5d8
+timeCreated: 1700841610

--- a/Runtime/SimpleGraphQL/Query.cs
+++ b/Runtime/SimpleGraphQL/Query.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text;
 using JetBrains.Annotations;
 
 namespace SimpleGraphQL
@@ -32,6 +34,11 @@ namespace SimpleGraphQL
         /// </summary>
         public string Source;
 
+        /// <summary>
+        /// Fragments used by this query
+        /// </summary>
+        public string[] Fragments;
+        
         public override string ToString()
         {
             return $"{FileName}:{OperationName}:{OperationType}";
@@ -41,14 +48,24 @@ namespace SimpleGraphQL
     [PublicAPI]
     public static class QueryExtensions
     {
-        public static Request ToRequest(this Query query, object variables = null)
+        public static Request ToRequest(this Query query, object variables = null, IEnumerable<Fragment> fragments = null)
         {
-            return new Request
+            StringBuilder querySource = new StringBuilder(query.Source);
+
+            if (fragments != null)
             {
-                Query = query.Source,
-                Variables = variables,
-                OperationName = query.OperationName,
-            };
+                foreach (var fragment in fragments)
+                {
+                    querySource.AppendLine(fragment?.Source);
+                }
+            }
+            
+            return new Request
+                   {
+                       Query = querySource.ToString(),
+                       Variables = variables,
+                       OperationName = query.OperationName,
+                   };
         }
     }
 


### PR DESCRIPTION
This has no priority right now but it may be useful in the future to differentiate only some parts of some queries between platforms using [Fragments](https://www.apollographql.com/docs/react/data/fragments/)

- .graphqlfrag files are parsed as GraphQLFragmentFile that contain a Fragment definition
- It's possible to add fragments in GraphQLConfig that are loaded in a Dictionary in GraphQLClient
- Queries now contain a list of all Fragment names that they references, that list can be used to get Fragments from the graphql client
- Query.ToRequest accept an IEnumerable to append Fragments to the query

To make it work in addition to this PR it requires to change the request creation in `GraphQLUtility:QueryInternal` like this:

```
var fragments = _client.FindFragments(query.Fragments);
var request = query.ToRequest(args, fragments);
```